### PR TITLE
Fix union types

### DIFF
--- a/src/state_machine.cr
+++ b/src/state_machine.cr
@@ -62,7 +62,7 @@ class StateMachine(T)
     @transitions_for[event].has_key?(@state)
   end
 
-  def when(event : Symbol, transitions : Hash(T, T))
-    @transitions_for[event] = transitions
+  def when(event : Symbol, transitions : NamedTuple)
+    @transitions_for[event] = transitions.to_h
   end
 end

--- a/src/state_machine.cr
+++ b/src/state_machine.cr
@@ -6,8 +6,7 @@ class StateMachine(T)
 
   def initialize(@state : T)
     @transitions_for = Hash(Symbol, Hash(T, T)).new
-
-    @callbacks = Hash(T | Symbol, Array).new { |hash, key|
+    @callbacks = Hash(T | Symbol, Array(Symbol ->)).new { |hash, key|
       hash[key] = Array(Symbol ->).new
     }
   end

--- a/src/state_machine.cr
+++ b/src/state_machine.cr
@@ -4,26 +4,26 @@ class StateMachine(T)
 
   getter :state
 
-  def initialize(@state : T)
+  def initialize(@state : T) : Void
     @transitions_for = Hash(Symbol, Hash(T, T)).new
     @callbacks = Hash(T | Symbol, Array(Symbol ->)).new { |hash, key|
       hash[key] = Array(Symbol ->).new
     }
   end
 
-  def ==(other : T)
+  def ==(other : T) : Bool
     @state == other
   end
 
-  def events
+  def events : Array
     @transitions_for.keys
   end
 
-  def on(key : T | Symbol, &block : Symbol ->)
+  def on(key : T | Symbol, &block : Symbol ->) : Void
     @callbacks[key].push block
   end
 
-  def states
+  def states : String
     states = Set(T).new
 
     @transitions_for.each_value do |transitions|
@@ -34,7 +34,7 @@ class StateMachine(T)
     states.to_a
   end
 
-  def trigger(event : Symbol)
+  def trigger(event : Symbol) : Bool
     if trigger?(event)
       @state = @transitions_for[event][@state]
 
@@ -48,7 +48,7 @@ class StateMachine(T)
     end
   end
 
-  def trigger!(event : Symbol)
+  def trigger!(event : Symbol) : Bool
     if trigger(event)
       true
     else
@@ -56,13 +56,13 @@ class StateMachine(T)
     end
   end
 
-  def trigger?(event : Symbol)
+  def trigger?(event : Symbol) : Bool
     raise InvalidEvent.new("Invalid event '#{event}'") unless @transitions_for.has_key?(event)
 
     @transitions_for[event].has_key?(@state)
   end
 
-  def when(event : Symbol, transitions : NamedTuple)
+  def when(event : Symbol, transitions : NamedTuple) : Hash
     @transitions_for[event] = transitions.to_h
   end
 end

--- a/src/state_machine.cr
+++ b/src/state_machine.cr
@@ -4,26 +4,26 @@ class StateMachine(T)
 
   getter :state
 
-  def initialize(@state : T)
+  def initialize(@state : T) : Void
     @transitions_for = Hash(Symbol, Hash(T, T)).new
     @callbacks = Hash(T | Symbol, Array(Symbol ->)).new { |hash, key|
       hash[key] = Array(Symbol ->).new
     }
   end
 
-  def ==(other : T)
+  def ==(other : T) : Bool
     @state == other
   end
 
-  def events
+  def events : Array(Symbol | String)
     @transitions_for.keys
   end
 
-  def on(key : T | Symbol, &block : Symbol ->)
+  def on(key : T | Symbol, &block : Symbol ->) : Void
     @callbacks[key].push block
   end
 
-  def states
+  def states : String
     states = Set(T).new
 
     @transitions_for.each_value do |transitions|
@@ -34,7 +34,7 @@ class StateMachine(T)
     states.to_a
   end
 
-  def trigger(event : Symbol)
+  def trigger(event : Symbol) : Bool
     if trigger?(event)
       @state = @transitions_for[event][@state]
 
@@ -48,7 +48,7 @@ class StateMachine(T)
     end
   end
 
-  def trigger!(event : Symbol)
+  def trigger!(event : Symbol) : Bool
     if trigger(event)
       true
     else
@@ -56,13 +56,13 @@ class StateMachine(T)
     end
   end
 
-  def trigger?(event : Symbol)
+  def trigger?(event : Symbol) : Bool
     raise InvalidEvent.new("Invalid event '#{event}'") unless @transitions_for.has_key?(event)
 
     @transitions_for[event].has_key?(@state)
   end
 
-  def when(event : Symbol, transitions : NamedTuple)
+  def when(event : Symbol, transitions : NamedTuple) : Hash
     @transitions_for[event] = transitions.to_h
   end
 end


### PR DESCRIPTION
Detailed union types.
its needed after lang updates with typification of union classes for instance variables.

NamedTuple.to_h instead of Hash(T, T)
now, '{key: value}' in method args generates the NamedTuple, which is very inconvenient to explicitly typecast.
there is a reason why i put '.to_h'. I hope its a temporary measure until release of normal detailed typification syntax of any Unions